### PR TITLE
Use correct bundle for class when loading nib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## 2.1.1
+
+* Fixed bundle location of nibs.
+  [@chrisamanse](https://github.com/chrisamanse), [#10](https://github.com/AliSoftware/Reusable/pull/10)
+
+By default, `nib: UINib` of `NibLoadable` protocol will use the nib located in the bundle of the conforming class.
+
 ## 2.1.0
 
 * Added support for direct instantiation of arbitrary `UIView` from a nib.  

--- a/Sources/NibLoadable.swift
+++ b/Sources/NibLoadable.swift
@@ -14,7 +14,7 @@ public extension NibLoadable {
   /// By default, use the nib which have the same name as the name of the class,
   /// and located in the bundle of that class
   static var nib: UINib {
-    return UINib(nibName: String(Self), bundle: NSBundle(forClass: self))
+    return UINib(nibName: String(self), bundle: NSBundle(forClass: self))
   }
 }
 

--- a/Sources/NibLoadable.swift
+++ b/Sources/NibLoadable.swift
@@ -12,9 +12,9 @@ public protocol NibLoadable: class {
 
 public extension NibLoadable {
   /// By default, use the nib which have the same name as the name of the class,
-  /// and located in the main bundle
+  /// and located in the bundle of that class
   static var nib: UINib {
-    return UINib(nibName: String(Self), bundle: nil)
+    return UINib(nibName: String(Self), bundle: NSBundle(forClass: self))
   }
 }
 

--- a/Sources/Reusable.swift
+++ b/Sources/Reusable.swift
@@ -18,7 +18,7 @@ public protocol NibReusable: Reusable, NibLoadable {}
 public extension Reusable {
   /// By default, use the name of the class as String for its reuseIdentifier
   static var reuseIdentifier: String {
-    return String(Self)
+    return String(self)
   }
 }
 


### PR DESCRIPTION
- use correct bundle for class using `init(forClass: AnyClass)` initializer of `NSBundle`
- for use with nibs in dynamic frameworks