### PR TITLE
Renamed storyboard property to unified sceneStoryboard

### DIFF
--- a/Example/ReusableDemo/Storyboards/InfoDetailViewController.swift
+++ b/Example/ReusableDemo/Storyboards/InfoDetailViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 import Reusable
 
 final class InfoDetailViewController: UIViewController, StoryboardSceneBased {
-  static let storyboard = UIStoryboard(name: "InfoViewController", bundle: nil)
+  static let sceneStoryboard = UIStoryboard(name: "InfoViewController", bundle: nil)
 
   @IBOutlet private weak var detailsLabel: UILabel!
   private var detailsText: String?

--- a/Reusable.xcworkspace/contents.xcworkspacedata
+++ b/Reusable.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:Reusable/Reusable.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/Reusable/Reusable.xcodeproj/project.pbxproj
+++ b/Reusable/Reusable.xcodeproj/project.pbxproj
@@ -1,0 +1,476 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		3820E58F1DDFC9FC0030DE04 /* Reusable.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3820E5851DDFC9FC0030DE04 /* Reusable.framework */; };
+		3820E5941DDFC9FC0030DE04 /* ReusableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3820E5931DDFC9FC0030DE04 /* ReusableTests.swift */; };
+		3820E5961DDFC9FC0030DE04 /* Reusable.h in Headers */ = {isa = PBXBuildFile; fileRef = 3820E5881DDFC9FC0030DE04 /* Reusable.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3820E5A91DDFCA0F0030DE04 /* StoryboardBased.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3820E5A11DDFCA0F0030DE04 /* StoryboardBased.swift */; };
+		3820E5AA1DDFCA0F0030DE04 /* StoryboardSceneBased.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3820E5A21DDFCA0F0030DE04 /* StoryboardSceneBased.swift */; };
+		3820E5AB1DDFCA0F0030DE04 /* NibLoadable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3820E5A41DDFCA0F0030DE04 /* NibLoadable.swift */; };
+		3820E5AC1DDFCA0F0030DE04 /* NibOwnerLoadable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3820E5A51DDFCA0F0030DE04 /* NibOwnerLoadable.swift */; };
+		3820E5AD1DDFCA0F0030DE04 /* Reusable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3820E5A61DDFCA0F0030DE04 /* Reusable.swift */; };
+		3820E5AE1DDFCA0F0030DE04 /* UICollectionView+Reusable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3820E5A71DDFCA0F0030DE04 /* UICollectionView+Reusable.swift */; };
+		3820E5AF1DDFCA0F0030DE04 /* UITableView+Reusable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3820E5A81DDFCA0F0030DE04 /* UITableView+Reusable.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		3820E5901DDFC9FC0030DE04 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 3820E57C1DDFC9FC0030DE04 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 3820E5841DDFC9FC0030DE04;
+			remoteInfo = Reusable;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		3820E5851DDFC9FC0030DE04 /* Reusable.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Reusable.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		3820E5881DDFC9FC0030DE04 /* Reusable.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Reusable.h; sourceTree = "<group>"; };
+		3820E5891DDFC9FC0030DE04 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		3820E58E1DDFC9FC0030DE04 /* ReusableTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ReusableTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		3820E5931DDFC9FC0030DE04 /* ReusableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReusableTests.swift; sourceTree = "<group>"; };
+		3820E5951DDFC9FC0030DE04 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		3820E5A11DDFCA0F0030DE04 /* StoryboardBased.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoryboardBased.swift; sourceTree = "<group>"; };
+		3820E5A21DDFCA0F0030DE04 /* StoryboardSceneBased.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoryboardSceneBased.swift; sourceTree = "<group>"; };
+		3820E5A41DDFCA0F0030DE04 /* NibLoadable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NibLoadable.swift; sourceTree = "<group>"; };
+		3820E5A51DDFCA0F0030DE04 /* NibOwnerLoadable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NibOwnerLoadable.swift; sourceTree = "<group>"; };
+		3820E5A61DDFCA0F0030DE04 /* Reusable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Reusable.swift; sourceTree = "<group>"; };
+		3820E5A71DDFCA0F0030DE04 /* UICollectionView+Reusable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UICollectionView+Reusable.swift"; sourceTree = "<group>"; };
+		3820E5A81DDFCA0F0030DE04 /* UITableView+Reusable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UITableView+Reusable.swift"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		3820E5811DDFC9FC0030DE04 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3820E58B1DDFC9FC0030DE04 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3820E58F1DDFC9FC0030DE04 /* Reusable.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		3820E57B1DDFC9FC0030DE04 = {
+			isa = PBXGroup;
+			children = (
+				3820E59F1DDFCA0F0030DE04 /* Sources */,
+				3820E5871DDFC9FC0030DE04 /* Reusable */,
+				3820E5921DDFC9FC0030DE04 /* ReusableTests */,
+				3820E5861DDFC9FC0030DE04 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		3820E5861DDFC9FC0030DE04 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				3820E5851DDFC9FC0030DE04 /* Reusable.framework */,
+				3820E58E1DDFC9FC0030DE04 /* ReusableTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		3820E5871DDFC9FC0030DE04 /* Reusable */ = {
+			isa = PBXGroup;
+			children = (
+				3820E5881DDFC9FC0030DE04 /* Reusable.h */,
+				3820E5891DDFC9FC0030DE04 /* Info.plist */,
+			);
+			path = Reusable;
+			sourceTree = "<group>";
+		};
+		3820E5921DDFC9FC0030DE04 /* ReusableTests */ = {
+			isa = PBXGroup;
+			children = (
+				3820E5931DDFC9FC0030DE04 /* ReusableTests.swift */,
+				3820E5951DDFC9FC0030DE04 /* Info.plist */,
+			);
+			path = ReusableTests;
+			sourceTree = "<group>";
+		};
+		3820E59F1DDFCA0F0030DE04 /* Sources */ = {
+			isa = PBXGroup;
+			children = (
+				3820E5A01DDFCA0F0030DE04 /* Storyboard */,
+				3820E5A31DDFCA0F0030DE04 /* View */,
+			);
+			name = Sources;
+			path = ../Sources;
+			sourceTree = "<group>";
+		};
+		3820E5A01DDFCA0F0030DE04 /* Storyboard */ = {
+			isa = PBXGroup;
+			children = (
+				3820E5A11DDFCA0F0030DE04 /* StoryboardBased.swift */,
+				3820E5A21DDFCA0F0030DE04 /* StoryboardSceneBased.swift */,
+			);
+			path = Storyboard;
+			sourceTree = "<group>";
+		};
+		3820E5A31DDFCA0F0030DE04 /* View */ = {
+			isa = PBXGroup;
+			children = (
+				3820E5A41DDFCA0F0030DE04 /* NibLoadable.swift */,
+				3820E5A51DDFCA0F0030DE04 /* NibOwnerLoadable.swift */,
+				3820E5A61DDFCA0F0030DE04 /* Reusable.swift */,
+				3820E5A71DDFCA0F0030DE04 /* UICollectionView+Reusable.swift */,
+				3820E5A81DDFCA0F0030DE04 /* UITableView+Reusable.swift */,
+			);
+			path = View;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		3820E5821DDFC9FC0030DE04 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3820E5961DDFC9FC0030DE04 /* Reusable.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		3820E5841DDFC9FC0030DE04 /* Reusable */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 3820E5991DDFC9FC0030DE04 /* Build configuration list for PBXNativeTarget "Reusable" */;
+			buildPhases = (
+				3820E5801DDFC9FC0030DE04 /* Sources */,
+				3820E5811DDFC9FC0030DE04 /* Frameworks */,
+				3820E5821DDFC9FC0030DE04 /* Headers */,
+				3820E5831DDFC9FC0030DE04 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Reusable;
+			productName = Reusable;
+			productReference = 3820E5851DDFC9FC0030DE04 /* Reusable.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		3820E58D1DDFC9FC0030DE04 /* ReusableTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 3820E59C1DDFC9FC0030DE04 /* Build configuration list for PBXNativeTarget "ReusableTests" */;
+			buildPhases = (
+				3820E58A1DDFC9FC0030DE04 /* Sources */,
+				3820E58B1DDFC9FC0030DE04 /* Frameworks */,
+				3820E58C1DDFC9FC0030DE04 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				3820E5911DDFC9FC0030DE04 /* PBXTargetDependency */,
+			);
+			name = ReusableTests;
+			productName = ReusableTests;
+			productReference = 3820E58E1DDFC9FC0030DE04 /* ReusableTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		3820E57C1DDFC9FC0030DE04 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftUpdateCheck = 0810;
+				LastUpgradeCheck = 0810;
+				ORGANIZATIONNAME = AliSoftware;
+				TargetAttributes = {
+					3820E5841DDFC9FC0030DE04 = {
+						CreatedOnToolsVersion = 8.1;
+						LastSwiftMigration = 0810;
+						ProvisioningStyle = Automatic;
+					};
+					3820E58D1DDFC9FC0030DE04 = {
+						CreatedOnToolsVersion = 8.1;
+						LastSwiftMigration = 0810;
+						ProvisioningStyle = Automatic;
+					};
+				};
+			};
+			buildConfigurationList = 3820E57F1DDFC9FC0030DE04 /* Build configuration list for PBXProject "Reusable" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = 3820E57B1DDFC9FC0030DE04;
+			productRefGroup = 3820E5861DDFC9FC0030DE04 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				3820E5841DDFC9FC0030DE04 /* Reusable */,
+				3820E58D1DDFC9FC0030DE04 /* ReusableTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		3820E5831DDFC9FC0030DE04 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3820E58C1DDFC9FC0030DE04 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		3820E5801DDFC9FC0030DE04 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3820E5AB1DDFCA0F0030DE04 /* NibLoadable.swift in Sources */,
+				3820E5AC1DDFCA0F0030DE04 /* NibOwnerLoadable.swift in Sources */,
+				3820E5A91DDFCA0F0030DE04 /* StoryboardBased.swift in Sources */,
+				3820E5AE1DDFCA0F0030DE04 /* UICollectionView+Reusable.swift in Sources */,
+				3820E5AA1DDFCA0F0030DE04 /* StoryboardSceneBased.swift in Sources */,
+				3820E5AD1DDFCA0F0030DE04 /* Reusable.swift in Sources */,
+				3820E5AF1DDFCA0F0030DE04 /* UITableView+Reusable.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3820E58A1DDFC9FC0030DE04 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3820E5941DDFC9FC0030DE04 /* ReusableTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		3820E5911DDFC9FC0030DE04 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 3820E5841DDFC9FC0030DE04 /* Reusable */;
+			targetProxy = 3820E5901DDFC9FC0030DE04 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		3820E5971DDFC9FC0030DE04 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_SUSPICIOUS_MOVES = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		3820E5981DDFC9FC0030DE04 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_SUSPICIOUS_MOVES = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		3820E59A1DDFC9FC0030DE04 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Reusable/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.alisoftware.reusable;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
+			};
+			name = Debug;
+		};
+		3820E59B1DDFC9FC0030DE04 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Reusable/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.alisoftware.reusable;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
+			};
+			name = Release;
+		};
+		3820E59D1DDFC9FC0030DE04 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				DEVELOPMENT_TEAM = "";
+				INFOPLIST_FILE = ReusableTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.alisoftware.ReusableTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
+			};
+			name = Debug;
+		};
+		3820E59E1DDFC9FC0030DE04 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				DEVELOPMENT_TEAM = "";
+				INFOPLIST_FILE = ReusableTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.alisoftware.ReusableTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		3820E57F1DDFC9FC0030DE04 /* Build configuration list for PBXProject "Reusable" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				3820E5971DDFC9FC0030DE04 /* Debug */,
+				3820E5981DDFC9FC0030DE04 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		3820E5991DDFC9FC0030DE04 /* Build configuration list for PBXNativeTarget "Reusable" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				3820E59A1DDFC9FC0030DE04 /* Debug */,
+				3820E59B1DDFC9FC0030DE04 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		3820E59C1DDFC9FC0030DE04 /* Build configuration list for PBXNativeTarget "ReusableTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				3820E59D1DDFC9FC0030DE04 /* Debug */,
+				3820E59E1DDFC9FC0030DE04 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 3820E57C1DDFC9FC0030DE04 /* Project object */;
+}

--- a/Reusable/Reusable.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Reusable/Reusable.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:Reusable.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/Reusable/Reusable.xcodeproj/xcshareddata/xcschemes/Reusable.xcscheme
+++ b/Reusable/Reusable.xcodeproj/xcshareddata/xcschemes/Reusable.xcscheme
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0810"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "3820E5841DDFC9FC0030DE04"
+               BuildableName = "Reusable.framework"
+               BlueprintName = "Reusable"
+               ReferencedContainer = "container:Reusable.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "3820E58D1DDFC9FC0030DE04"
+               BuildableName = "ReusableTests.xctest"
+               BlueprintName = "ReusableTests"
+               ReferencedContainer = "container:Reusable.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "3820E5841DDFC9FC0030DE04"
+            BuildableName = "Reusable.framework"
+            BlueprintName = "Reusable"
+            ReferencedContainer = "container:Reusable.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "3820E5841DDFC9FC0030DE04"
+            BuildableName = "Reusable.framework"
+            BlueprintName = "Reusable"
+            ReferencedContainer = "container:Reusable.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "3820E5841DDFC9FC0030DE04"
+            BuildableName = "Reusable.framework"
+            BlueprintName = "Reusable"
+            ReferencedContainer = "container:Reusable.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Reusable/Reusable/Info.plist
+++ b/Reusable/Reusable/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/Reusable/Reusable/Reusable.h
+++ b/Reusable/Reusable/Reusable.h
@@ -1,0 +1,18 @@
+//
+//  Reusable.h
+//  Reusable
+//
+//  Created by Jakub Gert on 19/11/2016.
+//
+
+#import <UIKit/UIKit.h>
+
+//! Project version number for Reusable.
+FOUNDATION_EXPORT double ReusableVersionNumber;
+
+//! Project version string for Reusable.
+FOUNDATION_EXPORT const unsigned char ReusableVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <Reusable/PublicHeader.h>
+
+

--- a/Reusable/ReusableTests/Info.plist
+++ b/Reusable/ReusableTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/Reusable/ReusableTests/ReusableTests.swift
+++ b/Reusable/ReusableTests/ReusableTests.swift
@@ -1,0 +1,35 @@
+//
+//  ReusableTests.swift
+//  ReusableTests
+//
+//  Created by Jakub Gert on 19/11/2016.
+//
+
+import XCTest
+@testable import Reusable
+
+class ReusableTests: XCTestCase {
+    
+    override func setUp() {
+        super.setUp()
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+    
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        super.tearDown()
+    }
+    
+    func testExample() {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    }
+    
+    func testPerformanceExample() {
+        // This is an example of a performance test case.
+        self.measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+    
+}

--- a/Sources/Storyboard/StoryboardBased.swift
+++ b/Sources/Storyboard/StoryboardBased.swift
@@ -17,14 +17,14 @@ import UIKit
 /// to be able to instantiate them from the Storyboard in a type-safe manner
 public protocol StoryboardBased: class {
   /// The UIStoryboard to use when we want to instantiate this ViewController
-  static var storyboard: UIStoryboard { get }
+  static var sceneStoryboard: UIStoryboard { get }
 }
 
 // MARK: Default Implementation
 
 public extension StoryboardBased {
   /// By default, use the storybaord with the same name as the class
-  static var storyboard: UIStoryboard {
+  static var sceneStoryboard: UIStoryboard {
     return UIStoryboard(name: String(describing: self), bundle: Bundle(for: self))
   }
 }
@@ -38,8 +38,8 @@ public extension StoryboardBased where Self: UIViewController {
    - returns: instance of the conforming ViewController
    */
   static func instantiate() -> Self {
-    guard let vc = storyboard.instantiateInitialViewController() as? Self else {
-      fatalError("The initialViewController of '\(storyboard)' is not of class '\(self)'")
+    guard let vc = sceneStoryboard.instantiateInitialViewController() as? Self else {
+      fatalError("The initialViewController of '\(sceneStoryboard)' is not of class '\(self)'")
     }
     return vc
   }

--- a/Sources/Storyboard/StoryboardSceneBased.swift
+++ b/Sources/Storyboard/StoryboardSceneBased.swift
@@ -16,10 +16,10 @@ import UIKit
 ///
 /// to be able to instantiate them from the Storyboard in a type-safe manner.
 ///
-/// You need to implement `storyboard` yourself to indicate the UIStoryboard this scene is from.
+/// You need to implement `sceneStoryboard` yourself to indicate the UIStoryboard this scene is from.
 public protocol StoryboardSceneBased: class {
   /// The UIStoryboard to use when we want to instantiate this ViewController
-  static var storyboard: UIStoryboard { get }
+  static var sceneStoryboard: UIStoryboard { get }
   /// The scene identifier to use when we want to instantiate this ViewController from its associated Storyboard
   static var sceneIdentifier: String { get }
 }
@@ -42,8 +42,8 @@ public extension StoryboardSceneBased where Self: UIViewController {
    - returns: instance of the conforming ViewController
    */
   static func instantiate() -> Self {
-    let storyboard = Self().storyboard
-    guard let vc = storyboard?.instantiateViewController(withIdentifier: self.sceneIdentifier) as? Self else {
+    let storyboard = Self.sceneStoryboard
+    guard let vc = storyboard.instantiateViewController(withIdentifier: self.sceneIdentifier) as? Self else {
       fatalError("The viewController '\(self.sceneIdentifier)' of '\(storyboard)' is not of class '\(self)'")
     }
     return vc


### PR DESCRIPTION
Current implementation for instantiating VC from storyboard is not working correctly.
Self().storyboard from StoryboardSceneBased.swift is creating new instance of VC and then reading "storyboard" property. However value of read property is not from StoryboardBased.storyboard (which is static) but from UIViewController.storyboard (which is optional).
I'm proposing small change (but it's breaking API change) by renaming property from 'storyboard' to 'sceneStoryboard' for avoid conflicts and make code working correctly.