### PR TITLE
Increasing safety in loadFromNib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # CHANGELOG
 
+## Unreleased
+
+* Removing a parameter from `loadFromNib(owner:)` method in `NibOwnerLoadable` due to a possibility of calling `init()` or
+  `init(frame:)` initializers which might led to a crash if `init(frame:)` was not implemented in a custom UIView subclass
+  (because it is not a required initializer).
+  Additionally, changing `loadFromNib(owner:)` to an instance method as for
+  classes conforming to NibOwnerLoadable, the instance of a class is already instantiated (i.e. when loading from other
+  XIBs). However, it is still possible to load such a view programatically.
+
+    ⚠️ **BREAKING CHANGES** ⚠️ The following method has a new signature:
+    - `static func loadFromNib(owner:)` is now `func loadNibContent()`
+    [@Skoti](https://github.com/Skoti)
+    [#40](https://github.com/AliSoftware/Reusable/pull/40)
+
+* Fixing incorrect protocol naming in documentation comments for CollectionHeaderView and MyXIBIndexSquaceCell
+  [@Skoti](https://github.com/Skoti)
+
+* Fixing table view controller scene to display cells above UITabBar
+  [@Skoti](https://github.com/Skoti)
+
 ## 3.0.1
 
 * Fix `instantiate()` implementation on `StoryboardSceneBased` ViewControllers.  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,22 +2,19 @@
 
 ## Unreleased
 
-* Removing a parameter from `loadFromNib(owner:)` method in `NibOwnerLoadable` due to a possibility of calling `init()` or
-  `init(frame:)` initializers which might led to a crash if `init(frame:)` was not implemented in a custom UIView subclass
-  (because it is not a required initializer).
-  Additionally, changing `loadFromNib(owner:)` to an instance method as for
-  classes conforming to NibOwnerLoadable, the instance of a class is already instantiated (i.e. when loading from other
-  XIBs). However, it is still possible to load such a view programatically.
+### Breaking change
 
-    ⚠️ **BREAKING CHANGES** ⚠️ The following method has a new signature:
-    - `static func loadFromNib(owner:)` is now `func loadNibContent()`
-    [@Skoti](https://github.com/Skoti)
-    [#40](https://github.com/AliSoftware/Reusable/pull/40)
+* `static func loadFromNib(owner:)` of `NibOwnerLoadable` has been replaced by instance method `func loadNibContent()`.  
+  This is more consistent and also avoids possible crashes when used with `UIView` subclasses not implementing non-required initializers `init()`/`init(frame:)`.  
+  [@Skoti](https://github.com/Skoti)
+  [#40](https://github.com/AliSoftware/Reusable/pull/40)
 
-* Fixing incorrect protocol naming in documentation comments for CollectionHeaderView and MyXIBIndexSquaceCell
+### Enhancements
+
+* Fixing documentation typos for `CollectionHeaderView` and `MyXIBIndexSquaceCell`.  
   [@Skoti](https://github.com/Skoti)
 
-* Fixing table view controller scene to display cells above UITabBar
+* Fixing table view controller scene in Example project, to display cells above `UITabBar`.  
   [@Skoti](https://github.com/Skoti)
 
 ## 3.0.1

--- a/Example/ReusableDemo/Base.lproj/Main.storyboard
+++ b/Example/ReusableDemo/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15G31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="7fF-Ae-xTS">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="16D32" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="7fF-Ae-xTS">
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
@@ -90,6 +90,7 @@
                             <outlet property="delegate" destination="Spa-tB-Bt1" id="iqn-sB-Tfo"/>
                         </connections>
                     </tableView>
+                    <extendedEdge key="edgesForExtendedLayout" top="YES"/>
                     <tabBarItem key="tabBarItem" title="TableView" id="C3o-Lt-Bjj"/>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="XEN-tN-mKX" userLabel="First Responder" sceneMemberID="firstResponder"/>

--- a/Example/ReusableDemo/CollectionViewCells/CollectionHeaderView.swift
+++ b/Example/ReusableDemo/CollectionViewCells/CollectionHeaderView.swift
@@ -16,7 +16,7 @@ import Reusable
  * It is also reusable and has a `reuseIdentifier` (as it's a CollectionViewCell
  * and it uses the CollectionView recycling mechanism) => it is `Reusable`
  *
- * That's why it's annotated with the `NibOwnerLoadable` protocol,
+ * That's why it's annotated with the `NibReusable` protocol,
  * Which in fact is just a convenience typealias that combines
  * `NibLoadable` & `Reusable` protocols.
  */

--- a/Example/ReusableDemo/CollectionViewCells/MyXIBIndexSquaceCell.swift
+++ b/Example/ReusableDemo/CollectionViewCells/MyXIBIndexSquaceCell.swift
@@ -16,7 +16,7 @@ import Reusable
  * It is also reusable and has a `reuseIdentifier` (as it's a CollectionViewCell
  * and it uses the CollectionView recycling mechanism) => it is `Reusable`
  *
- * That's why it's annotated with the `NibOwnerLoadable` protocol,
+ * That's why it's annotated with the `NibReusable` protocol,
  * Which in fact is just a typealias that combines
  * `NibLoadable` & `Reusable` protocols.
  */

--- a/Example/ReusableDemo/CustomViews/MyCustomWidget.swift
+++ b/Example/ReusableDemo/CustomViews/MyCustomWidget.swift
@@ -26,9 +26,6 @@ class MyCustomWidget: UIView, NibOwnerLoadable {
 
   required init?(coder aDecoder: NSCoder) {
     super.init(coder: aDecoder)
-    MyCustomWidget.loadFromNib(owner: self)
-  }
-  override init(frame: CGRect) {
-    super.init(frame: frame)
+    self.loadNibContent()
   }
 }

--- a/Example/ReusableDemo/TableViewCells/MyHeaderTableView.swift
+++ b/Example/ReusableDemo/TableViewCells/MyHeaderTableView.swift
@@ -22,6 +22,7 @@ final class MyHeaderTableView: UIView, NibOwnerLoadable {
 
   override init(frame: CGRect) {
     super.init(frame: frame)
+    self.loadNibContent()
   }
 
   required init?(coder aDecoder: NSCoder) {

--- a/Example/ReusableDemo/TableViewCells/MyHeaderTableView.swift
+++ b/Example/ReusableDemo/TableViewCells/MyHeaderTableView.swift
@@ -15,7 +15,7 @@ import Reusable
  *
  * That's why it's annotated with the `NibOwnerLoadable` protocol.
  */
-final class MyHeaderTableView: UIView, NibOwnerLoadable, FrameInitializable {
+final class MyHeaderTableView: UIView, NibOwnerLoadable {
 
   @IBOutlet private weak var titleLabel: UILabel!
   static let height: CGFloat = 55

--- a/Example/ReusableDemo/TableViewCells/MyHeaderTableView.swift
+++ b/Example/ReusableDemo/TableViewCells/MyHeaderTableView.swift
@@ -15,7 +15,7 @@ import Reusable
  *
  * That's why it's annotated with the `NibOwnerLoadable` protocol.
  */
-final class MyHeaderTableView: UIView, NibOwnerLoadable {
+final class MyHeaderTableView: UIView, NibOwnerLoadable, FrameInitializable {
 
   @IBOutlet private weak var titleLabel: UILabel!
   static let height: CGFloat = 55

--- a/Example/ReusableDemo/TableViewController.swift
+++ b/Example/ReusableDemo/TableViewController.swift
@@ -27,7 +27,8 @@ final class TableViewController: UITableViewController {
   }
 
   override func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-    let view = MyHeaderTableView.loadFromNib()
+    let view = MyHeaderTableView(frame: CGRect(x: 0, y: 0, width: tableView.bounds.size.width, height: self.tableView(tableView, heightForHeaderInSection: section)))
+    view.loadNibContent()
     view.fillForSection(section)
     return view
   }

--- a/Example/ReusableDemo/TableViewController.swift
+++ b/Example/ReusableDemo/TableViewController.swift
@@ -27,8 +27,12 @@ final class TableViewController: UITableViewController {
   }
 
   override func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-    let view = MyHeaderTableView(frame: CGRect(x: 0, y: 0, width: tableView.bounds.size.width, height: self.tableView(tableView, heightForHeaderInSection: section)))
-    view.loadNibContent()
+    let frame = CGRect(x: 0, y: 0, width: tableView.bounds.size.width, height: self.tableView(tableView, heightForHeaderInSection: section))
+    
+    // See the overridden `MyHeaderTableView.init(frame:)` initializer, which
+    // automatically loads the view content from its nib using loadNibContent()
+    let view = MyHeaderTableView(frame: frame)
+    
     view.fillForSection(section)
     return view
   }

--- a/README.md
+++ b/README.md
@@ -297,17 +297,14 @@ final class MyCustomWidget: UIView, NibOwnerLoadable {
   …
   required init?(coder aDecoder: NSCoder) {
     super.init(coder: aDecoder)
-    MyCustomWidget.loadFromNib(owner: self)
-  }
-  override init(frame: CGRect) {
-    super.init(frame: frame)
+    self.loadNibContent()
   }
 }
 ```
 
 Overriding `init?(coder:)` allows your `MyCustomWidget` custom view to load its content from the associated XIB `MyCustomWidget.xib` and add it as subviews of itself.
 
-_💡 Note: overriding `init(frame:)`, even just to call `super.init(frame: frame)` might seems pointless, but seems necessary in some cases due to a strange issue with Swift and dynamic dispatch not being able to detect and call the superclass implementation all by itself: I've sometimes seen crashes when not implementing it explicitly, so better safe than sorry._
+_💡 Note: possible to override `init(frame:)`, in order to be able to create an instance of that view programatically and call `loadNibContent()` to fill with views if needed.
 
 ## 3b. Instantiating a `NibLoadable` view
 
@@ -321,8 +318,6 @@ let view2 = NibBasedRootView.loadFromNib() // Create another one
 let view3 = NibBasedRootView.loadFromNib() // and another one
 …
 ```
-
-> 💡 You could also use `MyCustomWidget.loadFromNib()` on a `NibOwnerLoadable` — the same way we just did on `NibLoadable` views above — to load them by code if needs be too.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ final class MyCustomWidget: UIView, NibOwnerLoadable {
 
 Overriding `init?(coder:)` allows your `MyCustomWidget` custom view to load its content from the associated XIB `MyCustomWidget.xib` and add it as subviews of itself.
 
-_💡 Note: possible to override `init(frame:)`, in order to be able to create an instance of that view programatically and call `loadNibContent()` to fill with views if needed.
+_💡 Note: it is also possible to override `init(frame:)`, in order to be able to create an instance of that view programatically and call `loadNibContent()` to fill with views if needed.
 
 ## 3b. Instantiating a `NibLoadable` view
 

--- a/Sources/View/NibOwnerLoadable.swift
+++ b/Sources/View/NibOwnerLoadable.swift
@@ -41,38 +41,22 @@ public extension NibOwnerLoadable where Self: UIView {
    - returns: A `NibOwnerLoadable`, `UIView` instance
    */
   @discardableResult
-  static func loadFromNib(owner: Self) -> Self {
+  func loadNibContent() {
     let layoutAttributes: [NSLayoutAttribute] = [.top, .leading, .bottom, .trailing]
-    for view in nib.instantiate(withOwner: owner, options: nil) {
+    for view in Self.nib.instantiate(withOwner: self, options: nil) {
       if let view = view as? UIView {
         view.translatesAutoresizingMaskIntoConstraints = false
-        owner.addSubview(view)
+        self.addSubview(view)
         layoutAttributes.forEach { attribute in
-          owner.addConstraint(NSLayoutConstraint(item: view,
+          self.addConstraint(NSLayoutConstraint(item: view,
             attribute: attribute,
             relatedBy: .equal,
-            toItem: owner,
+            toItem: self,
             attribute: attribute,
             multiplier: 1,
             constant: 0.0))
         }
       }
     }
-    return owner
   }
-}
-
-public protocol FrameInitializable: class {
-    init(frame: CGRect)
-}
-
-public extension NibOwnerLoadable where Self: UIView, Self: FrameInitializable {
-    /**
-     Returns a `UIView` object instantiated from nib using a default owner instance
-     
-     - returns: A `NibOwnerLoadable`, `UIView`, `FrameInitializable` instance
-     */
-    static func loadFromNib() -> Self {
-        return Self.loadFromNib(owner: Self(frame: CGRect.zero))
-    }
 }

--- a/Sources/View/NibOwnerLoadable.swift
+++ b/Sources/View/NibOwnerLoadable.swift
@@ -38,11 +38,10 @@ public extension NibOwnerLoadable where Self: UIView {
 
    - parameter owner: The instance of the view which will be your File's Owner
                       (and to which you want to add the XIB's views as subviews).
-                      Defaults to a brand new instance if not provided.
-   - returns: A `NibOwnLoadable`, `UIView` instance
+   - returns: A `NibOwnerLoadable`, `UIView` instance
    */
   @discardableResult
-  static func loadFromNib(owner: Self = Self()) -> Self {
+  static func loadFromNib(owner: Self) -> Self {
     let layoutAttributes: [NSLayoutAttribute] = [.top, .leading, .bottom, .trailing]
     for view in nib.instantiate(withOwner: owner, options: nil) {
       if let view = view as? UIView {
@@ -61,4 +60,19 @@ public extension NibOwnerLoadable where Self: UIView {
     }
     return owner
   }
+}
+
+public protocol FrameInitializable: class {
+    init(frame: CGRect)
+}
+
+public extension NibOwnerLoadable where Self: UIView, Self: FrameInitializable {
+    /**
+     Returns a `UIView` object instantiated from nib using a default owner instance
+     
+     - returns: A `NibOwnerLoadable`, `UIView`, `FrameInitializable` instance
+     */
+    static func loadFromNib() -> Self {
+        return Self.loadFromNib(owner: Self(frame: CGRect.zero))
+    }
 }

--- a/Sources/View/NibOwnerLoadable.swift
+++ b/Sources/View/NibOwnerLoadable.swift
@@ -34,13 +34,8 @@ public extension NibOwnerLoadable {
 
 public extension NibOwnerLoadable where Self: UIView {
   /**
-   Returns a `UIView` object instantiated from nib
-
-   - parameter owner: The instance of the view which will be your File's Owner
-                      (and to which you want to add the XIB's views as subviews).
-   - returns: A `NibOwnerLoadable`, `UIView` instance
+   Adds content loaded from the nib to the end of the receiver's list of subviews and adds constraints automatically.
    */
-  @discardableResult
   func loadNibContent() {
     let layoutAttributes: [NSLayoutAttribute] = [.top, .leading, .bottom, .trailing]
     for view in Self.nib.instantiate(withOwner: self, options: nil) {


### PR DESCRIPTION
In NibOwnerLoadable extension there is this dangerous line where it is assumed that a class which inherits from UIView also implements `init(frame: CGRect)` initializer:

`static func loadFromNib(owner: Self = Self()) -> Self`

and if it does not it will crash in runtime.

I'm surprised that this even compiles, because according to the Swift [documentation](https://developer.apple.com/library/content/documentation/Swift/Conceptual/Swift_Programming_Language/Initialization.html):

> subclasses do not inherit their superclass initializers by default

> Write the required modifier before the definition of a class initializer to indicate that every subclass of the class must implement that initializer: 

and since: `required init?(coder aDecoder: NSCoder)` is the only required initializer in UIView class then it should be the only initializer to be possibly called on `Self` which is a **subclass** of UIView in this extension.

It is getting even more fun when you realize that this initializer is not called directly because in loadFromNib declaration, no-argument initializer `init()` from `NSObject` is used (which underneath seems to fallback to `init(frame:)` with `CGRect.zero` passed as an argument).
This is even more surprising in terms of compilation since the code below (which mimics NSObject and UIView initializers) does not compile:
```
class Base : NSObject {
}

class Subclass : Base {
    init(frame: CGRect){}
    required init?(coder aDecoder: NSCoder) {}
}

class Custom : Subclass {
    required init?(coder aDecoder: NSCoder) {
        super.init(coder: aDecoder)
    }
}

extension NibOwnerLoadable where Self : Subclass {
    static func testing(test: Self = Self()) -> Self {
        return test
    }
}
```
and produces compile-time error saying:
>Cannot invoke initializer for type 'Self' with no arguments

or if we change `where Self : Subclass` to `where Self : Base`
>Constructing an object of class type 'Self' with a metatype value must use a 'required' initializer

which is the best description of what is happening.

But for some reasons it compiles when using UIView ...

Having all this in mind, I have created a pull request for increased safety when using `init(frame: CGRect)` to explicitly say that this is possible by implementing `FrameInitializable` protocol.

So `loadFromNib()` with no arguments version is added to an extension of NibOwnerLoadable for UIView implementing `FrameInitializable` protocol and uses the argument version from NibOwnerLoadable extension for UIView. Consequently, the non-argument version does not need `@discardableResult` because one for sure needs to use the returned object, otherwise it is pointless calling this function.

This is a simple and small change and it expresses more explicitly what is actually needed for UIView to safely use `loadFromNib()` without owner parameter.