### PR TITLE
Bump Xcode version used by CircleCI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   xcode:
-    version: 8.2
+    version: 9.2
 
 dependencies:
   pre:


### PR DESCRIPTION
We now want to use Xcode 9.2 instead of 8.2