### PR TITLE
Specify Swift version for building from Xcode 10

### DIFF
--- a/Reusable.podspec
+++ b/Reusable.podspec
@@ -2,6 +2,7 @@ Pod::Spec.new do |s|
 
   s.name         = "Reusable"
   s.version      = "4.0.2"
+  s.swift_version = "4.0"
   s.summary      = "A Swift Mixin to deal with reusable UITableView & UICollectionView cells and XIB-based views"
 
   s.description  = <<-DESC


### PR DESCRIPTION
Successfully tested with Xcode 10 + Cocoapods 1.6.0 beta 1