### PR TITLE
Support for Swift 5.0

### DIFF
--- a/Reusable.podspec
+++ b/Reusable.podspec
@@ -32,7 +32,8 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target = "9.0"
 
   s.source       = { :git => "https://github.com/AliSoftware/Reusable.git", :tag => s.version.to_s }
-  s.swift_version = '4.2'
+  s.swift_version = '5.0'
+  s.swift_versions = '>= 4.2', '< 6.0'
 
   s.subspec 'View' do |ss|
     ss.source_files  = "Sources/View/*.swift"


### PR DESCRIPTION
With CocoaPods >= 1.7, you can use Swift 4.2 and more.