### PR TITLE
Fix Xcode 12.5 warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
-# CHANGELOG
+# CHANGELOG 
+
+## WIP
+* Fix Xcode 12.5 warnings about the class keyword for protocol inheritance that is deprecated.    
+  [@johnarn](https://github.com/johnarn)
+  [@AliSoftware](https://github.com/AliSoftware)
+  [#113](https://github.com/AliSoftware/Reusable/pull/113)
 
 ## 4.1.1
 

--- a/Sources/Storyboard/StoryboardBased.swift
+++ b/Sources/Storyboard/StoryboardBased.swift
@@ -16,7 +16,7 @@ import UIKit
 ///  * this ViewController is the initialViewController of your Storyboard
 ///
 /// to be able to instantiate them from the Storyboard in a type-safe manner
-public protocol StoryboardBased: class {
+public protocol StoryboardBased: AnyObject {
   /// The UIStoryboard to use when we want to instantiate this ViewController
   static var sceneStoryboard: UIStoryboard { get }
 }

--- a/Sources/Storyboard/StoryboardSceneBased.swift
+++ b/Sources/Storyboard/StoryboardSceneBased.swift
@@ -18,7 +18,7 @@ import UIKit
 /// to be able to instantiate them from the Storyboard in a type-safe manner.
 ///
 /// You need to implement `sceneStoryboard` yourself to indicate the UIStoryboard this scene is from.
-public protocol StoryboardSceneBased: class {
+public protocol StoryboardSceneBased: AnyObject {
   /// The UIStoryboard to use when we want to instantiate this ViewController
   static var sceneStoryboard: UIStoryboard { get }
   /// The scene identifier to use when we want to instantiate this ViewController from its associated Storyboard

--- a/Sources/View/NibLoadable.swift
+++ b/Sources/View/NibLoadable.swift
@@ -16,7 +16,7 @@ import UIKit
 ///  * this class is used as the XIB's root view
 ///
 /// to be able to instantiate them from the NIB in a type-safe manner
-public protocol NibLoadable: class {
+public protocol NibLoadable: AnyObject {
   /// The nib file to use to load a new instance of the View designed in a XIB
   static var nib: UINib { get }
 }

--- a/Sources/View/NibOwnerLoadable.swift
+++ b/Sources/View/NibOwnerLoadable.swift
@@ -16,7 +16,7 @@ import UIKit
 ///  * this class is used as the XIB's File's Owner
 ///
 /// to be able to instantiate them from the NIB in a type-safe manner
-public protocol NibOwnerLoadable: class {
+public protocol NibOwnerLoadable: AnyObject {
   /// The nib file to use to load a new instance of the View designed in a XIB
   static var nib: UINib { get }
 }

--- a/Sources/View/Reusable.swift
+++ b/Sources/View/Reusable.swift
@@ -14,7 +14,7 @@ import UIKit
 /// Make your `UITableViewCell` and `UICollectionViewCell` subclasses
 /// conform to this protocol when they are *not* NIB-based but only code-based
 /// to be able to dequeue them in a type-safe manner
-public protocol Reusable: class {
+public protocol Reusable: AnyObject {
   /// The reuse identifier to use when registering and later dequeuing a reusable cell
   static var reuseIdentifier: String { get }
 }


### PR DESCRIPTION
# Description
In Xcode 12.5 the following warning occurs
`the class keyword for protocol inheritance is deprecated`

As the proposal #[0156](https://github.com/apple/swift-evolution/blob/master/proposals/0156-subclass-existentials.md) says:

> This proposal merges the concepts of class and AnyObject , which now have the same meaning: they represent an existential for classes. To get rid of the duplication, we suggest only keeping AnyObject around. To reduce source-breakage to a minimum, class could be redefined as typealias class = AnyObject and give a deprecation warning on class for the first version of Swift this proposal is implemented in. Later, class could be removed in a subsequent version of Swift.

Both keywords behave identically. AnyObject is preferred because it is the name of a type and can appear anywhere that a type can. "class" is just special syntax in that one place in a protocol's inheritance clause, and it parses identically to "AnyObject".

# Changes
The changes that have been made were to replace class with AnyObject as class is deprecated.

# Review code
Please check my code and let me know if there are any problems.