### PR TITLE
Replace String(describing:) with String(reflecting:)

### DIFF
--- a/Sources/Storyboard/StoryboardSceneBased.swift
+++ b/Sources/Storyboard/StoryboardSceneBased.swift
@@ -30,7 +30,7 @@ public protocol StoryboardSceneBased: AnyObject {
 public extension StoryboardSceneBased {
   /// By default, use the `sceneIdentifier` with the same name as the class
   static var sceneIdentifier: String {
-    return String(describing: self)
+    return String(reflecting: self)
   }
 }
 

--- a/Sources/View/Reusable.swift
+++ b/Sources/View/Reusable.swift
@@ -29,7 +29,7 @@ public typealias NibReusable = Reusable & NibLoadable
 public extension Reusable {
   /// By default, use the name of the class as String for its reuseIdentifier
   static var reuseIdentifier: String {
-    return String(describing: self)
+    return String(reflecting: self)
   }
 }
 #endif


### PR DESCRIPTION
Different namespace but duplicate reuseIdentifier

Found a not very important issue, when two internal class names are the same, the`reuseIdentifier ` is also the same. If you use `String(reflecting:)`, you can use the full path identifier , which faster than `String(describing:)`. Of course, you can also override reuseIdentifier, or using two different class names, even if their namespaces are different.

```swift


import Foundation


public protocol Reusable: AnyObject {
	static var reuseIdentifier: String { get }
}

extension Reusable {
	public static var reuseIdentifier: String {
		return String(describing: self)
	}
	
	public static var reuseIdentifier2: String {
		return String(reflecting: self)
	}
}

class Compoment {
	class Header { 
		class Text: Reusable {
	
		}
	}
	class Text: Reusable {
		
	}
}

print(Compoment.Text.reuseIdentifier)

var date = Date()
print(Compoment.Header.Text.reuseIdentifier)
print(-date.timeIntervalSinceNow * 1000)

date = Date()
print(Compoment.Header.Text.reuseIdentifier2)
print(-date.timeIntervalSinceNow * 1000)



//Text
//Text
//0.014066696166992188
//main.Compoment.Header.Text
//0.0069141387939453125

```