### PR TITLE
Added support for UICollectionViewLayout Decoration View

### DIFF
--- a/Sources/View/UICollectionViewLayout+Reusable.swift
+++ b/Sources/View/UICollectionViewLayout+Reusable.swift
@@ -1,0 +1,30 @@
+/*********************************************
+ *
+ * This code is under the MIT License (MIT)
+ *
+ * Copyright (c) 2016 AliSoftware
+ *
+ *********************************************/
+
+#if canImport(UIKit)
+import UIKit
+
+public extension UICollectionReusableView {
+    static var elementKind: String {
+        return String(describing: self)
+    }
+}
+
+public extension UICollectionViewLayout {
+    final func register<T: UICollectionReusableView>(decorationViewType: T.Type)
+    where T: Reusable & NibLoadable {
+        self.register(decorationViewType.nib, forDecorationViewOfKind: decorationViewType.elementKind)
+    }
+    
+    final func register<T: UICollectionReusableView>(decorationViewType: T.Type)
+    where T: Reusable {
+        self.register(decorationViewType.self, forDecorationViewOfKind: decorationViewType.elementKind)
+    }
+}
+
+#endif


### PR DESCRIPTION
### Old Style

```swift
import UIKit

class MyCollectionViewLayout: UICollectionViewCompositionalLayout {
    required init?(coder: NSCoder) {
        super.init { (section, layoutEnvironment) -> NSCollectionLayoutSection? in
            /* code */
        }

        let nib: UINib = .init(nibName: String(describing: MyCollectionReusableView.self), bundle: .main)
        register(nib, forDecorationViewOfKind: String(describing: MyCollectionReusableView.self))
    }
}
```

### New Style

```swift
import UIKit
import Reusable

class MyCollectionViewLayout: UICollectionViewCompositionalLayout {
    required init?(coder: NSCoder) {
        super.init { (section, layoutEnvironment) -> NSCollectionLayoutSection? in
            /* code */
        }

        register(decorationViewType: MyCollectionReusableView.self)
    }
}
```